### PR TITLE
:dancers: Run tests in containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,7 @@ sudo: required
 services:
   - docker
 
-language: node_js
-
-node_js:
-- node
 script:
-- npm run lint
-- npm run generate-coverage
-- npm run check-coverage
-- npm run upload-coverage-coveralls
+  - docker build --build-arg NODE_ENV=development -t nhsuk/profiles .
+  - docker run -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN nhsuk/profiles sh -c "cd /code && npm run git-hook && npm run upload-coverage-coveralls"
 


### PR DESCRIPTION
Instead of running the tests on the CI's host OS this change runs them inside of the container. Using the `git-hook` script, linting is done, tests are run, code coverage generated and uploaded to coveralls in a way that means coveralls will have the information available to communicate back to GitHub to inform the status of the check (which is why there is passing of `TRAVIS...` env vars through to the shell).