### PR TITLE
Feature/add gp placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const helmet = require('helmet');
+const gpLookup = require('./app/middleware/gpLookup');
 
 const app = express();
 
@@ -8,6 +9,14 @@ app.use(helmet());
 
 app.get('/', (req, res) => {
   res.send('Hello World!');
+});
+
+app.get('/gp-surgeries/:orgCode', (req, res) => {
+  res.send(`GP Page for ${gpLookup(req.params.orgCode).name}`);
+});
+
+app.get('/gp-surgeries/:orgCode/book-a-gp-appointment', (req, res) => {
+  res.send(`Book an appointment at ${gpLookup(req.params.orgCode).name}`);
 });
 
 module.exports = app;

--- a/app/middleware/gpLookup.js
+++ b/app/middleware/gpLookup.js
@@ -1,0 +1,19 @@
+const sampleGPs = {
+  A81001: {
+    organisation_code: 'A81001',
+    name: 'The Densham Surgery',
+    location: {
+      address: 'The Health Centre, Lawson Street, Stockton, Cleveland',
+      postcode: 'TS18 1HU',
+      latitude: 54.561691284179688,
+      longitude: -1.3189228773117065
+    },
+    contact_telephone_number: '01642 672351'
+  }
+};
+
+function getGP(orgCode) {
+  return sampleGPs[orgCode] || { name: 'Unknown Practice' };
+}
+
+module.exports = getGP;

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -43,7 +43,6 @@ describe('app', () => {
         .end((err, res) => {
           expect(err).to.equal(null);
           expect(res).to.have.status(200);
-          // eslint-disable-next-line no-unused-expressions
           expect(res.text).to.contain('GP Page');
           done();
         });
@@ -56,7 +55,6 @@ describe('app', () => {
         .end((err, res) => {
           expect(err).to.equal(null);
           expect(res).to.have.status(200);
-          // eslint-disable-next-line no-unused-expressions
           expect(res.text).to.contain('Unknown Practice');
           done();
         });
@@ -70,7 +68,6 @@ describe('app', () => {
         .end((err, res) => {
           expect(err).to.equal(null);
           expect(res).to.have.status(200);
-          // eslint-disable-next-line no-unused-expressions
           expect(res.text).to.contain('Book an appointment');
           done();
         });

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -49,6 +49,19 @@ describe('app', () => {
         });
     });
   });
+  describe('GP page', () => {
+    it('should return Unknown Practice GP Page for an invalid Org Code', (done) => {
+      chai.request(app)
+        .get('/gp-surgeries/12345')
+        .end((err, res) => {
+          expect(err).to.equal(null);
+          expect(res).to.have.status(200);
+          // eslint-disable-next-line no-unused-expressions
+          expect(res.text).to.contain('Unknown Practice');
+          done();
+        });
+    });
+  });
 
   describe('Book a GP appointment page', () => {
     it('should return a book a GP Appointment Page for a valid Org Code', (done) => {

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -23,7 +23,7 @@ describe('app', () => {
   });
 
   describe('default page', () => {
-    it('should return a 200 response as html', () => {
+    it('should return a 200 response as html', (done) => {
       chai.request(app)
         .get('/')
         .end((err, res) => {
@@ -31,6 +31,35 @@ describe('app', () => {
           expect(res).to.have.status(200);
           // eslint-disable-next-line no-unused-expressions
           expect(res).to.be.html;
+          done();
+        });
+    });
+  });
+
+  describe('GP page', () => {
+    it('should return a GP Page for a valid Org Code', (done) => {
+      chai.request(app)
+        .get('/gp-surgeries/A81001')
+        .end((err, res) => {
+          expect(err).to.equal(null);
+          expect(res).to.have.status(200);
+          // eslint-disable-next-line no-unused-expressions
+          expect(res.text).to.contain('GP Page');
+          done();
+        });
+    });
+  });
+
+  describe('Book a GP appointment page', () => {
+    it('should return a book a GP Appointment Page for a valid Org Code', (done) => {
+      chai.request(app)
+        .get('/gp-surgeries/A81001/book-a-gp-appointment')
+        .end((err, res) => {
+          expect(err).to.equal(null);
+          expect(res).to.have.status(200);
+          // eslint-disable-next-line no-unused-expressions
+          expect(res.text).to.contain('Book an appointment');
+          done();
         });
     });
   });


### PR DESCRIPTION
Initial placeholder structure for GP Surgery and book a GP appointment pages.

Routes return text only at the moment and there is only one valid org code: A81001
Sample URLS:
 http://profiles-pr-8.dev.c2s.nhschoices.net/gp-surgeries/A81001
http://profiles-pr-8.dev.c2s.nhschoices.net/gp-surgeries/A81001/book-a-gp-appointment