### PR TITLE
:put_litter_in_its_place: Delete generated css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-public/components
+public/css/
 coverage/
 
 .sass-cache


### PR DESCRIPTION
There are no `public/components`, in this repo they are stored under `public/css`.
When this is deployed to a test environment need to check the styling is available. If so, all is good.

Fixes #24 