### PR TITLE
:video_camera: Remove Travis env vars from repo file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ node_js:
 services:
   - docker
 
-env:
-  global:
-  - DOCKER_COMPOSE_VERSION=1.11.1
-  - DOCKER_REPO=nhsuk/profiles
-  - DOCKER_USERNAME=nhsukautomata
-  - RANCHER_TEMPLATE_NAME=c2s-profiles
-  - RANCHER_URL=https://rancher.nhschoices.net
-
 before_install:
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -33,4 +25,3 @@ script:
 
 after_script:
   - docker-compose -f docker-compose-tests.yml down -v
-


### PR DESCRIPTION
Based on the discussion around not having build env vars stored within the repo this change gets rid of them.