### PR TITLE
Feature/normal user tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /code
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 
-COPY npm-shrinkwrap.json /code
+COPY npm-shrinkwrap.json package.json /code/
 RUN if [ "$NODE_ENV" == "production" ]; then npm install --quiet --only=prod; else npm install --quiet ; fi
 
 EXPOSE 3000

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -9,7 +9,6 @@ services:
     command: npm run watch-test
     volumes:
       - profiles-tests-node_modules:/code/node_modules
-    user: root
     environment:
       NODE_ENV: test
     links:
@@ -22,7 +21,6 @@ services:
     command: sh -c "npm run travis"
     volumes:
       - profiles-travis-tests-node_modules:/code/node_modules
-    user: root
     environment:
       COVERALLS_REPO_TOKEN: ${COVERALLS_REPO_TOKEN}
       NODE_ENV: development

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -19,6 +19,7 @@ services:
       file: docker-compose.yml
       service: base-app
     command: sh -c "npm run travis"
+    user: root
     volumes:
       - profiles-travis-tests-node_modules:/code/node_modules
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     command: npm run watch-dev
     volumes:
       - .:/code
-    user: root
     environment:
       NODE_ENV: ${NODE_ENV-development}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     command: npm run watch-dev
     volumes:
       - .:/code
+    user: root
     environment:
       NODE_ENV: ${NODE_ENV-development}
 
@@ -28,4 +29,3 @@ services:
 
 volumes:
   profiles-node_modules:
-

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "snyk-test": "snyk test",
     "git-hook": "npm run lint && npm run generate-unit-coverage && npm run check-unit-coverage",
     "travis": "npm run lint && npm run generate-coverage && npm run check-coverage && npm run upload-coverage-coveralls",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A couple of small  tweaks:

* Remove running `snyk-protect` on `prepublish` which required the user to be running as `root` and as a consequence there is no need to set the user as `root`
* Copy over `package.json` (as in other repos) to prevent missing asset warnings