### PR TITLE
Feature/custom link tracking

### DIFF
--- a/app/views/includes/how-to-register.nunjucks
+++ b/app/views/includes/how-to-register.nunjucks
@@ -6,7 +6,7 @@
   </p>
 </div>
 <div>
-  <p>Find out <a href="http://www.nhs.uk/NHSEngland/AboutNHSservices/doctors/Pages/NHSGPs.aspx#register">how to register as a patient</a>.</p>
+  <p>Find out <a href="http://www.nhs.uk/NHSEngland/AboutNHSservices/doctors/Pages/NHSGPs.aspx#register" class="gp-website-register">how to register as a patient</a>.</p>
 </div>
 {% else %}
 <div class="callout callout--info">
@@ -15,7 +15,7 @@
   </p>
 </div>
 <div>
-  <p>You can still find out <a href="http://www.nhs.uk/NHSEngland/AboutNHSservices/doctors/Pages/NHSGPs.aspx#register">how to register with other surgeries</a>.</p>
+  <p>You can still find out <a href="http://www.nhs.uk/NHSEngland/AboutNHSservices/doctors/Pages/NHSGPs.aspx#register" class="gp-website-register-other">how to register with other surgeries</a>.</p>
 </div>
 {% endif %}
 <hr class="hr--fullwidth"/>

--- a/public/js/custom-hj.js
+++ b/public/js/custom-hj.js
@@ -13,12 +13,9 @@ jQuery(function($) {
       'gp-website-opening-times' : 'Website Opening Times'
     }
 
-    $('a').on('touchstart click', function () {
-      elem = $(this);
-      $.each( anchors, function( key, value ){
-        if ( $(elem).hasClass(key) ) {
-          hj('tagRecording', [value]);
-        }
+    $.each(anchors , function(prop, val) {
+      $('a.' + prop).on('touchstart click', function () {
+        hj('tagRecording', [val]);
       });
     });
   });

--- a/public/js/custom-hj.js
+++ b/public/js/custom-hj.js
@@ -1,25 +1,25 @@
 jQuery(function($) {
   $(document).ready(function () {
-    $('.gp-email').on('click', function () {
-      hj('tagRecording', ['Email']);
-    });
-    $('.gp-book-online').on('click', function () {
-      hj('tagRecording', ['Book Online']);
-    });
-    $('.repeat-prescription-online').on('click', function () {
-      hj('tagRecording', ['Repeat Prescriptions Online']);
-    });
-    $('.coded-records-online').on('click', function () {
-      hj('tagRecording', ['Medical Record Online']);
-    });
-    $('.gp-patient-survey').on('click', function () {
-      hj('tagRecording', ['Patient Survey']);
-    });
-    $('.gp-website').on('click', function () {
-      hj('tagRecording', ['Website']);
-    });
-    $('.gp-website-opening-times').on('click', function () {
-      hj('tagRecording', ['Website Opening Times']);
+
+    var anchors = {
+      'gp-email' : 'Email',
+      'gp-book-online' : 'Book Online',
+      'repeat-prescription-online' : 'Repeat Prescriptions Online',
+      'coded-records-online' : 'Medical Record Online',
+      'gp-patient-survey' : 'Patient Survey',
+      'gp-website' : 'Website',
+      'gp-website-register' : 'How to register as a patient',
+      'gp-website-register-other' : 'How to register with other surgeries',
+      'gp-website-opening-times' : 'Website Opening Times'
+    }
+
+    $('a').on('touchstart click', function () {
+      elem = $(this);
+      $.each( anchors, function( key, value ){
+        if ( $(elem).hasClass(key) ) {
+          hj('tagRecording', [value]);
+        }
+      });
     });
   });
 });

--- a/public/js/custom-wt.js
+++ b/public/js/custom-wt.js
@@ -1,24 +1,30 @@
 jQuery(function($) {
   $(document).ready(function () {
-    $('.gp-email').on('click', function () {
+    $('.gp-email').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Email', 'WT.dl', '121']});
     });
-    $('.gp-book-online').on('click', function () {
+    $('.gp-book-online').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Booking', 'WT.dl', '121']});
     });
-    $('.repeat-prescription-online').on('click', function () {
+    $('.repeat-prescription-online').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Repeat-Prescription', 'WT.dl', '121']});
     });
-    $('.coded-records-online').on('click', function () {
+    $('.coded-records-online').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Medical-Record', 'WT.dl', '121']});
     });
-    $('.gp-patient-survey').on('click', function () {
+    $('.gp-patient-survey').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Patient_Survey', 'WT.dl', '121']});
     });
-    $('.gp-website').on('click', function () {
+    $('.gp-website-register').on('touchstart click', function () {
+      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Register_Patient', 'WT.dl', '121']});
+    });
+    $('.gp-website-register-other').on('touchstart click', function () {
+      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Register_Other', 'WT.dl', '121']});
+    });
+    $('.gp-website').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Website', 'WT.dl', '121']});
     });
-    $('.gp-website-opening-times').on('click', function () {
+    $('.gp-website-opening-times').on('touchstart click', function () {
       Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Website_OpeningTimes', 'WT.dl', '121']});
     });
   });

--- a/public/js/custom-wt.js
+++ b/public/js/custom-wt.js
@@ -13,12 +13,9 @@ jQuery(function($) {
       'gp-website-opening-times' : 'GP-Website_OpeningTimes'
     }
 
-    $('a').on('touchstart click', function () {
-      elem = $(this);
-      $.each( anchors, function( key, value ){
-        if ( $(elem).hasClass(key) ) {
-          Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', value, 'WT.dl', '121']});
-        }
+    $.each(anchors , function(prop, val) {
+      $('a.' + prop).on('touchstart click', function () {
+        Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', val, 'WT.dl', '121']});
       });
     });
   });

--- a/public/js/custom-wt.js
+++ b/public/js/custom-wt.js
@@ -1,31 +1,25 @@
 jQuery(function($) {
   $(document).ready(function () {
-    $('.gp-email').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Email', 'WT.dl', '121']});
-    });
-    $('.gp-book-online').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Booking', 'WT.dl', '121']});
-    });
-    $('.repeat-prescription-online').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Repeat-Prescription', 'WT.dl', '121']});
-    });
-    $('.coded-records-online').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Medical-Record', 'WT.dl', '121']});
-    });
-    $('.gp-patient-survey').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Patient_Survey', 'WT.dl', '121']});
-    });
-    $('.gp-website-register').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Register_Patient', 'WT.dl', '121']});
-    });
-    $('.gp-website-register-other').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Register_Other', 'WT.dl', '121']});
-    });
-    $('.gp-website').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Website', 'WT.dl', '121']});
-    });
-    $('.gp-website-opening-times').on('touchstart click', function () {
-      Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', 'GP-Website_OpeningTimes', 'WT.dl', '121']});
+
+    var anchors = {
+      'gp-email' : 'GP-Email',
+      'gp-book-online' : 'GP-Booking',
+      'repeat-prescription-online' : 'GP-Repeat-Prescription',
+      'coded-records-online' : 'GP-Medical-Record',
+      'gp-patient-survey' : 'GP-Patient_Survey',
+      'gp-website-register' : 'GP-Register_Patient',
+      'gp-website-register-other' : 'GP-Register_Other',
+      'gp-website' : 'GP-Websitet',
+      'gp-website-opening-times' : 'GP-Website_OpeningTimes'
+    }
+
+    $('a').on('touchstart click', function () {
+      elem = $(this);
+      $.each( anchors, function( key, value ){
+        if ( $(elem).hasClass(key) ) {
+          Webtrends.multiTrack({argsa: ['DCSext.CTSLinkClicks', value, 'WT.dl', '121']});
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
@ajthomascouk This PR has got a cleaned up revision history. I've not moved away from `$.each` as it would have required changing `anchors` to an array rather than an object in order to have compatibility for < IE 9 as `Object.keys` is only an IE 9+ compatible feature.
There are likely additional improvements to make at some point wrt to `anchors` and the different values used by WT and HJ, however, I think that is for another time.

Fixes #133