### PR TITLE
Initial schema.org implementation

### DIFF
--- a/app/views/includes/schema.nunjucks
+++ b/app/views/includes/schema.nunjucks
@@ -1,0 +1,44 @@
+ <script type="application/ld+json">
+{
+  "@context" : "http://schema.org",
+  "@type" : "Physician",
+  "name" : "{{gp.name}}",
+  "telephone" : "{{ gp.contact.telephone }}",
+  "email" : "{{ gp.contact.email }}",
+  "identifier" : "{{ gp.odsCode }}",
+  "address" : {
+    "@type" : "PostalAddress",
+    "streetAddress" : "{{gp.address.addressLines}}",
+    "addressLocality" : "{{gp.address.addressLines}}",
+    "postalCode" : "{{ gp.address.postcode }}"
+    
+  },
+  "geo" : 
+  {
+    "@type": "GeoCoordinates",
+    "latitude": "{{gp.location.latitude}}",
+    "longitude": "73.98"
+    },
+  
+  "openingHoursSpecification" : [ {
+    "@type" : "OpeningHoursSpecification",
+    "dayOfWeek" : {
+      "@type" : "DayOfWeek",
+      "name" : "Monday"
+    },
+    "description" : "Reception",
+    "opens" : "09:00",
+    "closes" : "12:00"
+  }, {
+  "@type" : "OpeningHoursSpecification",
+    "dayOfWeek" : {
+      "@type" : "DayOfWeek",
+      "name" : "Monday"
+    },
+    "description" : "Surgery",
+    "opens" : "09:00",
+    "closes" : "12:00"
+  }],
+  "url" : {{gp.contact.website}},
+  "isAcceptingNewPatients" : "{{gp.acceptingNewPatients}}"
+}

--- a/app/views/layout.nunjucks
+++ b/app/views/layout.nunjucks
@@ -40,7 +40,7 @@
         })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
       </script>
     {% endif %}
-
+     {% include "includes/schema.nunjucks" %}
     {% block meta %}{% endblock %}
   </head>
 


### PR DESCRIPTION
This is a very early implementation of schema.org markup for organisations.

GP's are classed as Physicians within the schema. Currently only the basic org info has been tagged up, with an example of Opening hours for Reception and the Surgery hours.

Potential issues noted are:
- Lack of Lat/Long
- Need to split out address data
- Opening times needs some work (help is most likely required for this!)
- Services have not been tagged up as there is more work to be done around standardising this
- Facilities have not been included
- Accepting new patients has been added from the life sciences schema.
- JSON-LD is the preferred method for including schema.org info 
