### PR TITLE
Encode maps URL

### DIFF
--- a/app/lib/mapLink.js
+++ b/app/lib/mapLink.js
@@ -1,8 +1,9 @@
+const qs = require('querystring');
+
 function generateUrl(gp) {
-  const name = gp.name;
-  const address = gp.address.addressLines;
-  const postcode = gp.address.postcode;
-  const url = `https://maps.google.com/?q=${name},${address},${postcode}`.replace(/ /g, '+');
+  const query = `${gp.name},${gp.address.addressLines},${gp.address.postcode}`;
+  const encodedQuery = qs.escape(query);
+  const url = `https://maps.google.com/?q=${encodedQuery}`;
 
   return url;
 }

--- a/test/unit/lib/mapLink.js
+++ b/test/unit/lib/mapLink.js
@@ -1,17 +1,21 @@
+const qs = require('querystring');
 const chai = require('chai');
 const mapLink = require('../../../app/lib/mapLink.js');
 
 const expect = chai.expect;
 
 describe('mapLink', () => {
-  it('returns a fully qualified google map url', () => {
+  it('returns a fully qualified, URI encoded google map url', () => {
     const gp = {};
-
     gp.name = 'Gilberdyke Health Centre';
     gp.address = {};
-    gp.address.addressLines = 'The Health Centre,Thornton Dam Lane,Gilberdyke,Gilberdyke';
+    gp.address.addressLines = 'The Health & Centre,Thornton Dam Lane,Gilberdyke,Gilberdyke';
     gp.address.postcode = 'HU15 2UL';
-    const expectedResult = 'https://maps.google.com/?q=Gilberdyke+Health+Centre,The+Health+Centre,Thornton+Dam+Lane,Gilberdyke,Gilberdyke,HU15+2UL';
+
+    const expectedQuery = `${gp.name},${gp.address.addressLines},${gp.address.postcode}`;
+    const encodedQuery = qs.escape(expectedQuery);
+    const expectedResult = `https://maps.google.com/?q=${encodedQuery}`;
+
     const result = mapLink.generateUrl(gp);
 
     expect(result).to.be.equal(expectedResult);


### PR DESCRIPTION
Fixes an issue caused by not encoded the query string for the google maps link. Example page that was previously broken and is now fixed https://profiles-pr-212.dev.beta.nhschoices.net/gp-surgeries/44866